### PR TITLE
单文件上传，自动复制URL地址到剪贴板

### DIFF
--- a/app/components/services/settings.js
+++ b/app/components/services/settings.js
@@ -10,6 +10,14 @@ angular.module('web')
           return localStorage.setItem('autoUpgrade', v);
         }
       },
+      autoCopyURL: {
+        get: function () {
+          return parseInt(localStorage.getItem('autoCopyURL') || 0);
+        },
+        set: function (v) {
+          return localStorage.setItem('autoCopyURL', v);
+        }
+      },
       isCame: {
         get: function () {
           return parseInt(localStorage.getItem('isCame') || 0);

--- a/app/index.html
+++ b/app/index.html
@@ -58,7 +58,7 @@
     <script src="aliyun-sdk-oss.js"></script>
     <script src="templates.js"></script>
     <script>
-      const {ipcRenderer,shell,clipboard} = require('electron');
+      const {ipcRenderer,shell} = require('electron');
       var isDev = process.env.NODE_ENV=='development';
 
       ipcRenderer.on('asynchronous-reply', (event, data) => {

--- a/app/index.html
+++ b/app/index.html
@@ -58,7 +58,7 @@
     <script src="aliyun-sdk-oss.js"></script>
     <script src="templates.js"></script>
     <script>
-      const {ipcRenderer,shell} = require('electron');
+      const {ipcRenderer,shell,clipboard} = require('electron');
       var isDev = process.env.NODE_ENV=='development';
 
       ipcRenderer.on('asynchronous-reply', (event, data) => {

--- a/app/main/modals/settings.html
+++ b/app/main/modals/settings.html
@@ -122,6 +122,24 @@
         </div>
       </div>
 
+      <div class="form-group">
+        <label class="col-sm-4 control-label">
+          <!-- 自动复制文件上传URL到剪贴板: -->
+          {{'settings.autoCopyURL'|translate}}:
+        </label>
+        <div class="col-sm-7">
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" name="autoCopyURL"
+                     ng-model="set.autoCopyURL"
+                     ng-change="setChange(form1,'autoCopyURL')"
+                     ng-true-value="1" ng-false-value="0" />
+              <!-- (自动下载更新包) -->
+              ({{'settings.autoCopyURL.msg'|translate}})
+            </label>
+          </div>
+        </div>
+      </div>
     </fieldset>
 
     <fieldset>

--- a/app/main/modals/settings.js
+++ b/app/main/modals/settings.js
@@ -8,6 +8,7 @@ angular.module('web')
       showTab: 3,
       set: {
         autoUpgrade: settingsSvs.autoUpgrade.get(),
+        autoCopyURL: settingsSvs.autoCopyURL.get(),
         maxUploadJobCount: settingsSvs.maxUploadJobCount.get(),
         maxDownloadJobCount: settingsSvs.maxDownloadJobCount.get(),
         showImageSnapshot: settingsSvs.showImageSnapshot.get(),

--- a/node/i18n/en-US.js
+++ b/node/i18n/en-US.js
@@ -197,6 +197,8 @@ module.exports = {
   'settings.success': 'Saved successfully',
   'settings.autoUpgrade': 'Auto update',
   'settings.autoUpgrade.msg': 'Download update package automatically',
+  'settings.autoCopyURL': 'Clipboard',
+  'settings.autoCopyURL.msg': 'Automatically copy file uploaded URL to clipboard',
 
   //bookmark
   'bookmarks.title': 'Bookmarks',

--- a/node/i18n/ja-JP.js
+++ b/node/i18n/ja-JP.js
@@ -187,6 +187,8 @@ module.exports = {
   'settings.success': '保存を完了しました',
   'settings.autoUpgrade': '自動更新',
   'settings.autoUpgrade.msg': 'アップデートパッケージを自動的にダウンロードします',
+  'settings.autoCopyURL': 'クリップボード',
+  'settings.autoCopyURL.msg': 'ファイルのアップロードURLを自動的にクリップボードにコピーする',
   'settings.console': '試用パネル',
   'settings.console.msg': '調査を開く',
   'settings.file': "ローカルログファイル",

--- a/node/i18n/zh-CN.js
+++ b/node/i18n/zh-CN.js
@@ -188,6 +188,8 @@ module.exports = {
   'settings.success': '已经保存设置',
   'settings.autoUpgrade': '自动更新',
   'settings.autoUpgrade.msg': '自动下载更新包',
+  'settings.autoCopyURL': '剪贴板',
+  'settings.autoCopyURL.msg': '自动复制文件上传URL到剪贴板',
   'settings.console': '调试面板',
   'settings.console.msg': '开启调试',
   'settings.file': "本地日志文件",

--- a/node/ossstore/lib/upload-job.js
+++ b/node/ossstore/lib/upload-job.js
@@ -328,6 +328,17 @@ UploadJob.prototype.uploadSingle = function () {
                self.emit('complete');
                console.log('upload: '+self.from.path+' %celapse','background:green;color:white',self.endTime-self.startTime,'ms')
 
+               // 拼凑图片URL
+               var eptpl = self.oss.config.endpoint;
+               var protocol = eptpl.indexOf('https:') === 0 ? 'https:' : "http:";
+               var endpoint = eptpl.substr(8); // https://
+               var link = protocol + '//' + self.to.bucket + '.' + endpoint + '/' + encodeURI(self.to.key);
+               console.log(link);
+
+               // 自动复制到剪贴板
+               console.log('路径复制到剪贴板');
+               clipboard.writeText(link);
+
              }
           });
         }

--- a/node/ossstore/lib/upload-job.js
+++ b/node/ossstore/lib/upload-job.js
@@ -15,7 +15,7 @@ var isLogInfo = localStorage.getItem('logFileInfo')|| 0;
 //本地日志收集模块
 var log = require('electron-log');
 
-var { ipcRenderer} = require('electron');
+var { ipcRenderer, clipboard} = require('electron');
 
 class UploadJob extends Base {
 
@@ -328,16 +328,26 @@ UploadJob.prototype.uploadSingle = function () {
                self.emit('complete');
                console.log('upload: '+self.from.path+' %celapse','background:green;color:white',self.endTime-self.startTime,'ms')
 
-               // 拼凑图片URL
-               var eptpl = self.oss.config.endpoint;
-               var protocol = eptpl.indexOf('https:') === 0 ? 'https:' : "http:";
-               var endpoint = eptpl.substr(8); // https://
-               var link = protocol + '//' + self.to.bucket + '.' + endpoint + '/' + encodeURI(self.to.key);
-               console.log(link);
+               if (commonUtil.isAutoCopyURL() === 1) {
+                 // 拼凑图片URL
+                 var eptpl = self.oss.config.endpoint;
+                 var idx = 8;
+                 var protocol = 'https:';
+                 if (eptpl.indexOf('https:') === 0) {
+                   protocol = 'https:';
+                   idx = 8;
+                 } else {
+                   protocol = 'http:';
+                   idx = 7;
+                 }
+                 var endpoint = eptpl.substr(idx); // https:// 8    http:// 7
+                 var link = protocol + '//' + self.to.bucket + '.' + endpoint + '/' + encodeURI(self.to.key);
+                 console.log(link);
 
-               // 自动复制到剪贴板
-               console.log('路径复制到剪贴板');
-               clipboard.writeText(link);
+                 // 自动复制到剪贴板
+                 // console.log('路径已复制到剪贴板');
+                 clipboard.writeText(link);
+               }
 
              }
           });

--- a/node/ossstore/lib/util.js
+++ b/node/ossstore/lib/util.js
@@ -17,7 +17,8 @@ module.exports = {
   getBigFileMd5: getBigFileMd5,
   checkFileHash: checkFileHash,
   printPartTimeLine: printPartTimeLine,
-  getRetryTimes: getRetryTimes
+  getRetryTimes: getRetryTimes,
+  isAutoCopyURL: isAutoCopyURL
 };
 
 function printPartTimeLine(opt){
@@ -173,4 +174,8 @@ function parseOssPath(osspath) {
 
 function getRetryTimes() {
   return localStorage.getItem('uploadAndDownloadRetryTimes') || 10
+}
+
+function isAutoCopyURL() {
+  return parseInt(localStorage.getItem('autoCopyURL') || 0);
 }


### PR DESCRIPTION
每次写markdown，上传单个图片，要获取图片的URL，要经过“选中刚上传的图片”->“点击更多”->"获取地址"->“等待弹出窗口”->“点击复制地址”五个步骤，真的不胜其烦。

所以在上传成功后，判断是单个文件，那么自动复制文件路径到剪贴板要方便很多。

同时在设置项中，添加该项设置，考虑到其他用户的使用，默认禁用。

在Windows、Linux下测试通过。