### PR TITLE
fix: logout remove bucket info

### DIFF
--- a/app/components/services/auth.js
+++ b/app/components/services/auth.js
@@ -76,6 +76,7 @@ angular.module("web").factory("Auth", [
     }
 
     function logout() {
+      $rootScope.bucketMap = {};
       var df = $q.defer();
       AuthInfo.remove();
       df.resolve();

--- a/app/components/services/oss2.js
+++ b/app/components/services/oss2.js
@@ -957,49 +957,87 @@ angular.module("web").factory("ossSvs2", [
     }
 
     function saveContent(region, bucket, key, content) {
-      return new Promise(function (a, b) {
-        var client = getClient({
+      return new Promise(function (resolve, reject) {
+        // aliyun sdk, browser
+        const client = getClient({
           region: region,
           bucket: bucket,
         });
-
-        client.headObject(
-          {
-            Bucket: bucket,
-            Key: key,
-          },
-          function (err, result) {
-            if (err) {
-              handleError(err);
-              b(err);
-            } else {
-              client.putObject(
-                {
-                  Bucket: bucket,
-                  Key: key,
-                  Body: content,
-
-                  //保留http头
-                  ContentLanguage: result.ContentLanguage,
-                  ContentType: result.ContentType,
-                  CacheControl: result.CacheControl,
-                  ContentDisposition: result.ContentDisposition,
-                  ContentEncoding: "",
-                  Expires: result.Expires,
-                  Metadata: result.Metadata,
-                },
-                function (err) {
-                  if (err) {
-                    handleError(err);
-                    b(err);
-                  } else {
-                    a();
-                  }
-                }
-              );
-            }
+        // ali-oss, node
+        const client3 = getClient3({
+          region: region,
+          bucket: bucket,
+        })
+        Promise.all([
+          new Promise((resolve, reject) => {
+            client.headObject({Bucket: bucket, Key: key}, (err, result) => {
+              if (err) {
+                reject(err)
+              } else {
+                resolve(result)
+              }
+            })
+          }),
+          client3.getACL(key),
+          client3.getObjectTagging(key)
+        ]).then(([headResult, aclResult, taggingResult])=> {
+          let tagging = '';
+          if (taggingResult && taggingResult.tag) {
+            tagging = Object.keys(taggingResult.tag).map(function(k) {
+              return encodeURIComponent(k) + '=' + encodeURIComponent(data[k])
+            }).join('&')
           }
-        );
+          client3.put(key, new Buffer(content), {
+            mime: headResult.ContentType,
+            meta: headResult.Metadata,
+            headers: {
+              'Content-Disposition': headResult.ContentDisposition,
+              'Content-Encoding': headResult.ContentEncoding,
+              'Cache-Control': headResult.CacheControl,
+              'Content-Language': headResult.ContentLanguage,
+              'x-oss-storage-class': headResult.StorageClass,
+              'x-oss-object-acl': aclResult.acl,
+              'x-oss-tagging': tagging
+            }
+          }).then(resolve).catch(e => {
+            handleError(e);
+            reject(e);
+          });
+        }).catch(e => {
+          handleError(e);
+          reject(e);
+        })
+
+
+        // client.headObject({ Bucket: bucket, Key: key }, function (err, result) {
+        //   if (err) {
+        //     handleError(err);
+        //     reject(err);
+        //   } else {
+            // client.putObject({
+            //     Bucket: bucket,
+            //     Key: key,
+            //     Body: content,
+            //
+            //     //保留http头
+            //     ContentLanguage: result.ContentLanguage,
+            //     ContentType: result.ContentType,
+            //     CacheControl: result.CacheControl,
+            //     ContentDisposition: result.ContentDisposition,
+            //     ContentEncoding: "",
+            //     Expires: result.Expires,
+            //     Metadata: result.Metadata,
+            //   }, function (err) {
+            //     if (err) {
+            //       handleError(err);
+            //       reject(err);
+            //     } else {
+            //       resolve();
+            //     }
+            //   }
+            // );
+        //   }
+        // });
       });
     }
 
@@ -1353,7 +1391,7 @@ angular.module("web").factory("ossSvs2", [
           const dirs = (resp.prefixes || [])
             .filter((n) => n !== key)
             .map((n) => {
-              const arr = n.split('/').filter(k => !!k);
+              const arr = n.split("/").filter((k) => !!k);
               const name = arr[arr.length - 1];
               return {
                 isFolder: true,
@@ -1365,7 +1403,7 @@ angular.module("web").factory("ossSvs2", [
           const objects = (resp.objects || [])
             .filter((n) => n.name !== key)
             .map((n) => {
-              const arr = n.name.split('/').filter(k => !!k);
+              const arr = n.name.split("/").filter((k) => !!k);
               const name = arr[arr.length - 1];
               return Object.assign(n, {
                 isFile: true,

--- a/app/components/services/oss2.js
+++ b/app/components/services/oss2.js
@@ -1353,7 +1353,8 @@ angular.module("web").factory("ossSvs2", [
           const dirs = (resp.prefixes || [])
             .filter((n) => n !== key)
             .map((n) => {
-              const name = n.replace(key, "");
+              const arr = n.split('/').filter(k => !!k);
+              const name = arr[arr.length - 1];
               return {
                 isFolder: true,
                 itemType: "folder",
@@ -1364,11 +1365,13 @@ angular.module("web").factory("ossSvs2", [
           const objects = (resp.objects || [])
             .filter((n) => n.name !== key)
             .map((n) => {
+              const arr = n.name.split('/').filter(k => !!k);
+              const name = arr[arr.length - 1];
               return Object.assign(n, {
                 isFile: true,
                 itemType: "file",
                 path: n.name,
-                name: n.name.replace(key, ""),
+                name: name,
               });
             });
           return {

--- a/app/main/files/_/bucket-list.html
+++ b/app/main/files/_/bucket-list.html
@@ -31,7 +31,7 @@
     </tr>
 
     <tr
-      ng-repeat="item in buckets|filter:sch.bucketName"
+      ng-repeat="item in buckets|filter:{name: sch.bucketName}"
       context-menu="bucketMenuOptions"
       ng-dblclick="goIn(item.name)"
       ng-click="selectBucket(item);"

--- a/app/main/files/files.js
+++ b/app/main/files/files.js
@@ -624,7 +624,7 @@ angular
           .listFiles(info.region, info.bucket, info.key, marker || "")
           .then(
             function (result) {
-              var arr = result.data;
+              const arr = result.data;
               settingsSvs.showImageSnapshot.get() == 1
                 ? signPicURL(info, arr)
                 : null;

--- a/app/main/files/modals/update-http-headers-modal.js
+++ b/app/main/files/modals/update-http-headers-modal.js
@@ -35,6 +35,7 @@ angular.module("web").controller("updateHttpHeadersModalCtrl", [
     }
 
     init();
+
     function init() {
       $scope.isLoading = true;
       $scope.step = 2;
@@ -54,7 +55,7 @@ angular.module("web").controller("updateHttpHeadersModalCtrl", [
 
           var t = [];
           for (var k in result.Metadata) {
-            t.push({ key: k, value: result.Metadata[k] });
+            t.push({key: k, value: result.Metadata[k]});
           }
           $scope.metaItems = t;
 
@@ -91,23 +92,18 @@ angular.module("web").controller("updateHttpHeadersModalCtrl", [
       });
       //console.log(headers, metas)
       Toast.info(T("setting.on")); //'正在设置..'
-      Promise.all(
-        item.map((i) =>
-          ossSvs2.setMeta2(
-            currentInfo.region,
-            currentInfo.bucket,
-            i.path,
-            headers,
-            metas
-          )
-        )
-      )
-        .then(() => {
-          Toast.success(T("setting.success")); //'设置成功'
-        })
-        .finally(() => {
-          cancel();
-        });
+      Promise.all(item.map((i) =>
+        ossSvs2.setMeta2(
+          currentInfo.region,
+          currentInfo.bucket,
+          i.path,
+          headers,
+          metas
+        ))
+      ).then(() => {
+        Toast.success(T("setting.success")); //'设置成功'
+      })
+      cancel();
     }
   },
 ]);

--- a/main.js
+++ b/main.js
@@ -115,6 +115,7 @@ ipcMain.on("asynchronous", (event, data) => {
       event.sender.send("asynchronous-reply", { key: data.key, port: port });
       break;
     case "openDevTools":
+      process.env["DEBUG"] = 'ali-oss';
       win.webContents.openDevTools();
       break;
 


### PR DESCRIPTION
1. 修复登出后，没有清理bucket列表信息，导致下次在登录仍然使用上次bucket信息的bug。
2. 修复文件保存，无法保留ACL，storageClass 等信息的问题。
3. 使用node接口替换浏览器接口，以修复electorn 会把
Content-Type:text/plain; charset=utf-8 转成 Content-Type:text/plain; charset=UTF-8 导致无法保存报错的bug
4. 修复bucket和object搜索，失效问题。
5. 调试模式下增加node的 debug 信息